### PR TITLE
Fix undeclared variable res

### DIFF
--- a/shorty.js
+++ b/shorty.js
@@ -130,7 +130,7 @@
   };
 
   Shorty.prototype.readByte = function() {
-    res = 0;
+    var res = 0;
     for (var i=0; i<8; i++) res += (128>>i)*this.readBit();
     return String.fromCharCode(res);
   };


### PR DESCRIPTION
I just found an undeclared variable that was causing your script to not work properly 😮 ! (the inflate process didn't decompress my data back to what it was, and the browser didn't throw any error in the console)